### PR TITLE
fix: correct double brand-name substitution in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 
 TestMu AI is the world's first fully autonomous Agentic AI Quality Engineering Platform, enabling you to run your Jasmine tests at scale with intelligent automation, real-time insights, and seamless CI/CD integration.
 
-Run Jasmine tests on TestMu AI (Formerly TestMu AI (Formerly LambdaTest)) with full support for Node.js projects.
+Run Jasmine tests on TestMu AI (Formerly LambdaTest) with full support for Node.js projects.
 
-- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly TestMu AI (Formerly LambdaTest)).
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
 - Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
 
 ## Running locally
@@ -37,15 +37,15 @@ Run the following commands to setup the repository locally.
   
 - Push a new commit in the remote repository to trigger a new build on TAS.
 
-## TestMu AI (Formerly TestMu AI (Formerly LambdaTest)) Community
+## TestMu AI (Formerly LambdaTest) Community
 
 Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
 
-## TestMu AI (Formerly TestMu AI (Formerly LambdaTest)) Certifications
+## TestMu AI (Formerly LambdaTest) Certifications
 
 Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
 
-## Learning Resources by TestMu AI (Formerly TestMu AI (Formerly LambdaTest))
+## Learning Resources by TestMu AI (Formerly LambdaTest)
 
 Learn modern testing through tutorials, guides, videos, and weekly updates:
 


### PR DESCRIPTION
Fix double-substituted brand names and remove extra non-template badges.