### PR TITLE
fix: align README with standard TestMu AI template

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ With TestMu AI (Formerly LambdaTest), you can run Jasmine Tests across real brow
 - Node.js and npm (latest stable)
 - A TestMu AI (Formerly LambdaTest) account with your username and access key
 
+### Prerequisites
+
+- Node.js and npm (latest stable)
+- A TestMu AI (Formerly LambdaTest) account with your username and access key
+
 ## Running locally
 
 Run the following commands to setup the repository locally.


### PR DESCRIPTION
Full README restructure to match standard template: correct Getting Started, Prerequisites, Community/Certs/Learning blocks, License at end.